### PR TITLE
Excludes /dist/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 #Add files or extensions to ignore commiting
+/dist/


### PR DESCRIPTION
.gitignore now excludes the /dist/ directory